### PR TITLE
Minor fix: Change hourly forecast style and change units

### DIFF
--- a/src/helpers/HourlyForecast.js
+++ b/src/helpers/HourlyForecast.js
@@ -6,11 +6,13 @@ function HourlyForecast({results}) {
         labels: ['+1 H', '+2 H', '+3 H', '+4 H', '+5 H'],
         datasets: [
           {
-            label: 'Temperature in Celsius',
+            label: `Temperature (${results.unitText})`,
             data: [results.hourly[0].temp,results.hourly[1].temp,results.hourly[2].temp,results.hourly[3].temp,results.hourly[4].temp],
             fill: false,
             backgroundColor: 'rgb(255, 99, 132)',
-            borderColor: 'rgba(255, 99, 132, 0.2)',
+            borderColor: 'rgba(255, 99, 132, 0.5)',
+            borderWidth: 4,
+            pointRadius: 4,
           },
         ],
       };


### PR DESCRIPTION
The legend of the hourly forecast chart always says "Tempurature in Celsius" and I changed it to be consistent with the unit toggle. Besides I changed the chart style to make it easier to look.

![image](https://user-images.githubusercontent.com/51950361/142978755-a18f29e0-9ef6-4534-904b-4989b77423da.png)
